### PR TITLE
fix: make markdown preview text visible in dark mode

### DIFF
--- a/index.css
+++ b/index.css
@@ -137,7 +137,6 @@ textarea {
   flex-wrap: wrap;
 }
 /*Change made to make markdown preview text visible in dark mode*/
-/*Change made to make markdown preview text visible in dark mode*/
 body.dark-mode .toastui-editor-contents {
   color: #ffffff;
 }

--- a/index.css
+++ b/index.css
@@ -137,10 +137,14 @@ textarea {
   flex-wrap: wrap;
 }
 /*Change made to make markdown preview text visible in dark mode*/
-body.dark-mode .toastui-editor-contents p{
-  background-color: #121212; /* or any dark shade */
-  color: #ffffff; 
+/*Change made to make markdown preview text visible in dark mode*/
+body.dark-mode .toastui-editor-contents {
+  color: #ffffff;
 }
+body.dark-mode .toastui-editor-contents * {
+  color: #ffffff;
+}
+
 .preview-section {
   background-color: white;
   padding: 20px;

--- a/index.css
+++ b/index.css
@@ -136,7 +136,11 @@ textarea {
   margin-bottom: 15px;
   flex-wrap: wrap;
 }
-
+/*Change made to make markdown preview text visible in dark mode*/
+body.dark-mode .toastui-editor-contents p{
+  background-color: #121212; /* or any dark shade */
+  color: #ffffff; 
+}
 .preview-section {
   background-color: white;
   padding: 20px;


### PR DESCRIPTION
🔧 Fix: Markdown Preview Text Not Visible in Dark Mode
🐛 Problem
When switching to dark mode, the text content inside the markdown preview area was not visible due to insufficient contrast between the text color and the background.

✅ Solution
Added appropriate CSS styling for .preview content in dark mode.
Ensured that text inside the preview section uses a light color (#ffffff) when dark mode is active.
Verified visibility for various Markdown elements like paragraphs, headings, and lists.

🔍 Testing
Switched between light and dark modes.
Verified that text is visible and accessible in both themes.
No layout shifts or style breaks observed in either mode.

📌 Linked Issue
Fixes #56

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Improved readability of markdown preview text in dark mode by setting all text within the editor preview to white for better visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->