### PR TITLE
fix:added dark mode colour for markdown editor tabs

### DIFF
--- a/index.js
+++ b/index.js
@@ -327,6 +327,7 @@ function createFormatterTab(tabData = null) {
   textarea.addEventListener("input", () => updateFormatterPreview(tabId));
   updateFormatterPreview(tabId);
   enableTabReordering("formatter-tabs-container");
+  applyTabButtonTheme();
 }
 
 function switchFormatterTab(tabId) {
@@ -1548,6 +1549,16 @@ function renderMockgenDocs() {
 let editorTabCount = 0;
 const editorInstances = {};
 
+function applyTabButtonTheme() {
+  const isDark = document.body.classList.contains("dark-mode");
+  const buttons = document.querySelectorAll(".tab-button[data-tab]");
+
+  buttons.forEach((button) => {
+    button.style.backgroundColor = isDark ? "#2a2a2a" : "#ffffff";
+    button.style.color = isDark ? "#ffffff" : "#000000";
+  });
+}
+
 function addEditorTab(tabData = null) {
   let tabId;
   if (tabData?.id) {
@@ -1824,6 +1835,7 @@ function toggleShortcutModal() {
 
 function toggleDarkMode() {
   document.body.classList.toggle("dark-mode");
+  applyTabButtonTheme();
   saveGlobalState();
   // If the Compare section is visible, update all diff previews
   if (document.getElementById("compare-section").style.display !== "none") {


### PR DESCRIPTION
Fixes: #57 

**Markdown Editor in light mode**:
<img width="1137" alt="image" src="https://github.com/user-attachments/assets/9d656c0c-9e59-4738-9e36-f6e6dbac918f" />

**Markdown Editor in Dark Mode(before fix)**:
![image](https://github.com/user-attachments/assets/1f4bba7b-0d26-4a21-b719-992d2a675c53)

**Markdown Editor in Dark Mode(after fix)**:
<img width="1137" alt="image" src="https://github.com/user-attachments/assets/4aea6f50-841c-4f1c-9486-1944f30ea249" />

**How I fixed the bug**:-
- Added a JavaScript function(applyTabButtonTheme) which detects the current mode(light/dark) and based on it applies relevant background-colour and color changes to the tab buttons.
- This function is called when the Markdown editor loads initially(mounts) and every time whenever the mode is changed by the user.

Kindly let me know if any changes are required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Tab buttons now automatically update their background and text colors to match the selected light or dark mode theme.
- **Style**
	- Improved visual consistency of tab buttons when switching between light and dark modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->